### PR TITLE
Dict key mismatch in evaluation mode

### DIFF
--- a/examples/simple_trainer.py
+++ b/examples/simple_trainer.py
@@ -773,8 +773,12 @@ def main(cfg: Config):
     if cfg.ckpt is not None:
         # run eval only
         ckpt = torch.load(cfg.ckpt, map_location=runner.device)
+        runner_splats_key_to_ckpt_key = {"means": "means3d"}
         for k in runner.splats.keys():
-            runner.splats[k].data = ckpt["splats"][k]
+            if k in runner_splats_key_to_ckpt_key.keys():
+                runner.splats[k].data = ckpt["splats"][runner_splats_key_to_ckpt_key[k]]
+            else:
+                runner.splats[k].data = ckpt["splats"][k]
         runner.eval(step=ckpt["step"])
         runner.render_traj(step=ckpt["step"])
     else:


### PR DESCRIPTION
Issue: Hi, when I run the evaluation mode with the following command.

> python simple_trainer.py --disable_viewer --data_factor 8 --data_dir ../../../statue/ --result_dir ../../../results_test --ckpt ../../../results/statue_results/ckpts/ckpt_29999.pt

Error message: I encountered the following error.

>   ckpt = torch.load(cfg.ckpt, map_location=runner.device)
Traceback (most recent call last):
  File "/projects/MAD3D/ChengYou/CA3/debug/SpotLessSplats/examples/simple_trainer.py", line 794, in <module>
    main(cfg)
  File "/projects/MAD3D/ChengYou/CA3/debug/SpotLessSplats/examples/simple_trainer.py", line 780, in main
    runner.splats[k].data = ckpt["splats"][k]
KeyError: 'means'

Reason: I believe this is caused by a mismatch between the checkpoint and the runner dictionary keys. The checkpoint uses the key 'means3d', while the runner expects 'means'.

Solution: We can fix the bug by replacing the key with the correct one in the code.

> python simple_trainer.py --disable_viewer --data_factor 8 --data_dir ../../../statue/ --result_dir ../../../results_test --ckpt ../../../results/statue_results/ckpts/ckpt_29999.pt

> Running evaluation...
PSNR: 20.331, SSIM: 0.8306, LPIPS: 0.164 Time: 0.012s/image Number of GS: 490223
Running trajectory rendering...
Rendering trajectory: 100%|████████████████████████████████████████████████████████████████| 404/404 [00:01<00:00, 288.09it/s]
IMAGEIO FFMPEG_WRITER WARNING: input image is not divisible by macro_block_size=16, resizing from (504, 756) to (512, 768) to ensure video compatibility with most codecs and players. To prevent resizing, make your input image divisible by the macro_block_size or set the macro_block_size to 1 (risking incompatibility).
Video saved to ../../../results_test/videos/traj_29999.mp4





