### PR TITLE
Prevent colors overflow during training.

### DIFF
--- a/examples/spotless_trainer.py
+++ b/examples/spotless_trainer.py
@@ -588,6 +588,8 @@ class Runner:
                 colors, depths = renders[..., 0:3], renders[..., 3:4]
             else:
                 colors, depths = renders, None
+           
+            colors = torch.clamp(colors, 0., 1.0)
 
             if cfg.random_bkgd:
                 bkgd = torch.rand(1, 3, device=device)


### PR DESCRIPTION
Issue: The values in colors may slightly exceed the range of 1, which could cause overflow during image saving.

The overflow causes artifacts in the image, particularly in the sky region.
![train_ 0](https://github.com/user-attachments/assets/f058cc52-c02d-4b88-9ffd-f83909da8661)

Solution: Clip the values to the range [0, 1].

![train_ 0 (1)](https://github.com/user-attachments/assets/71f0a511-037f-4298-8660-4f47e363cbfe)

